### PR TITLE
Some porting to gtk3/vte3

### DIFF
--- a/terminal/terminal-app.c
+++ b/terminal/terminal-app.c
@@ -35,8 +35,6 @@
 #include <string.h>
 #endif
 
-#include <gdk/gdkkeysyms.h>
-
 #include <terminal/terminal-app.h>
 #include <terminal/terminal-config.h>
 #include <terminal/terminal-preferences.h>

--- a/terminal/terminal-preferences-dialog.c
+++ b/terminal/terminal-preferences-dialog.c
@@ -196,7 +196,7 @@ error:
 
   /* bind color properties */
   for (i = 0; i < G_N_ELEMENTS (props_color); i++)
-    BIND_PROPERTIES (props_color[i], "color");
+    BIND_PROPERTIES (props_color[i], "rgba");
 
   /* bind color properties */
   for (i = 0; i < G_N_ELEMENTS (props_value); i++)
@@ -498,12 +498,12 @@ static void
 terminal_preferences_dialog_palette_changed (GtkWidget                 *button,
                                              TerminalPreferencesDialog *dialog)
 {
-  gchar     name[16];
-  guint     i;
-  GObject  *obj;
-  GdkColor  color;
-  gchar    *color_str;
-  GString  *array;
+  gchar    name[16];
+  guint    i;
+  GObject *obj;
+  GdkRGBA  color;
+  gchar   *color_str;
+  GString *array;
 
   array = g_string_sized_new (225);
 
@@ -513,10 +513,10 @@ terminal_preferences_dialog_palette_changed (GtkWidget                 *button,
       g_snprintf (name, sizeof (name), "color-palette%d", i);
       obj = gtk_builder_get_object (GTK_BUILDER (dialog), name);
       terminal_return_if_fail (GTK_IS_COLOR_BUTTON (obj));
-      gtk_color_button_get_color (GTK_COLOR_BUTTON (obj), &color);
+      gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER (obj), &color);
 
       /* append to string */
-      color_str = gdk_color_to_string (&color);
+      color_str = gdk_rgba_to_string (&color);
       g_string_append (array, color_str);
       g_free (color_str);
 
@@ -536,12 +536,12 @@ terminal_preferences_dialog_palette_changed (GtkWidget                 *button,
 static void
 terminal_preferences_dialog_palette_notify (TerminalPreferencesDialog *dialog)
 {
-  gchar    *color_str;
-  gchar   **colors;
-  guint     i;
-  gchar     name[16];
-  GObject  *obj;
-  GdkColor  color;
+  gchar   *color_str;
+  gchar  **colors;
+  guint    i;
+  gchar    name[16];
+  GObject *obj;
+  GdkRGBA  color;
 
   g_object_get (dialog->preferences, "color-palette", &color_str, NULL);
   if (G_LIKELY (color_str != NULL))
@@ -558,8 +558,8 @@ terminal_preferences_dialog_palette_notify (TerminalPreferencesDialog *dialog)
             obj = gtk_builder_get_object (GTK_BUILDER (dialog), name);
             terminal_return_if_fail (GTK_IS_COLOR_BUTTON (obj));
 
-            if (gdk_color_parse (colors[i], &color))
-              gtk_color_button_set_color (GTK_COLOR_BUTTON (obj), &color);
+            if (gdk_rgba_parse (&color, colors[i]))
+              gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER (obj), &color);
           }
 
       g_strfreev (colors);

--- a/terminal/terminal-preferences.c
+++ b/terminal/terminal-preferences.c
@@ -152,14 +152,14 @@ static void
 transform_color_to_string (const GValue *src,
                            GValue       *dst)
 {
-  GdkColor *color;
-  gchar     buffer[32];
+  GdkRGBA *color;
+  gchar    buffer[8];
 
   color = g_value_get_boxed (src);
-  g_snprintf (buffer, 32, "#%04x%04x%04x",
-              (guint) color->red,
-              (guint) color->green,
-              (guint) color->blue);
+  g_snprintf (buffer, sizeof (buffer), "#%02x%02x%02x",
+              (guint) (color->red * 255),
+              (guint) (color->green * 255),
+              (guint) (color->blue * 255));
   g_value_set_string (dst, buffer);
 }
 
@@ -178,9 +178,9 @@ static void
 transform_string_to_color (const GValue *src,
                            GValue       *dst)
 {
-  GdkColor color;
+  GdkRGBA color;
 
-  gdk_color_parse (g_value_get_string (src), &color);
+  gdk_rgba_parse (&color, g_value_get_string (src));
   g_value_set_boxed (dst, &color);
 }
 
@@ -250,12 +250,12 @@ terminal_preferences_class_init (TerminalPreferencesClass *klass)
   gobject_class->set_property = terminal_preferences_set_property;
 
   /* register transform functions */
-  if (!g_value_type_transformable (GDK_TYPE_COLOR, G_TYPE_STRING))
-    g_value_register_transform_func (GDK_TYPE_COLOR, G_TYPE_STRING, transform_color_to_string);
+  if (!g_value_type_transformable (GDK_TYPE_RGBA, G_TYPE_STRING))
+    g_value_register_transform_func (GDK_TYPE_RGBA, G_TYPE_STRING, transform_color_to_string);
   if (!g_value_type_transformable (G_TYPE_STRING, G_TYPE_BOOLEAN))
     g_value_register_transform_func (G_TYPE_STRING, G_TYPE_BOOLEAN, transform_string_to_boolean);
-  if (!g_value_type_transformable (G_TYPE_STRING, GDK_TYPE_COLOR))
-    g_value_register_transform_func (G_TYPE_STRING, GDK_TYPE_COLOR, transform_string_to_color);
+  if (!g_value_type_transformable (G_TYPE_STRING, GDK_TYPE_RGBA))
+    g_value_register_transform_func (G_TYPE_STRING, GDK_TYPE_RGBA, transform_string_to_color);
   if (!g_value_type_transformable (G_TYPE_STRING, G_TYPE_DOUBLE))
     g_value_register_transform_func (G_TYPE_STRING, G_TYPE_DOUBLE, transform_string_to_double);
   if (!g_value_type_transformable (G_TYPE_STRING, G_TYPE_UINT))

--- a/terminal/terminal-search-dialog.c
+++ b/terminal/terminal-search-dialog.c
@@ -101,12 +101,12 @@ terminal_search_dialog_init (TerminalSearchDialog *dialog)
   gtk_dialog_add_action_widget (GTK_DIALOG (dialog), dialog->button_next, TERMINAL_RESPONSE_SEARCH_NEXT);
   gtk_widget_show (dialog->button_next);
 
-  vbox = gtk_vbox_new (FALSE, 6);
+  vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
   gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), vbox, TRUE, TRUE, 0);
   gtk_container_set_border_width (GTK_CONTAINER (vbox), 6);
   gtk_widget_show (vbox);
 
-  hbox = gtk_hbox_new (FALSE, 12);
+  hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
   gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, TRUE, 0);
   gtk_widget_show (hbox);
 

--- a/terminal/terminal-window-dropdown.c
+++ b/terminal/terminal-window-dropdown.c
@@ -265,7 +265,7 @@ terminal_window_dropdown_init (TerminalWindowDropdown *dropdown)
   gtk_action_set_visible (action, FALSE);
 
   /* notebook buttons */
-  hbox = gtk_hbox_new (TRUE, 2);
+  hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);
   gtk_notebook_set_action_widget (GTK_NOTEBOOK (window->notebook), hbox, GTK_PACK_END);
   gtk_widget_show (hbox);
 
@@ -336,13 +336,13 @@ terminal_window_dropdown_set_property (GObject      *object,
       break;
 
     case PROP_DROPDOWN_OPACITY:
-      screen = gtk_window_get_screen (GTK_WINDOW (dropdown));
+      screen = gtk_widget_get_screen (GTK_WIDGET (dropdown));
       if (gdk_screen_is_composited (screen))
         opacity = g_value_get_uint (value) / 100.0;
       else
         opacity = 1.00;
 
-      gtk_window_set_opacity (GTK_WINDOW (dropdown), opacity);
+      gtk_widget_set_opacity (GTK_WIDGET (dropdown), opacity);
       return;
 
     case PROP_DROPDOWN_STATUS_ICON:

--- a/terminal/terminal-window.c
+++ b/terminal/terminal-window.c
@@ -34,7 +34,6 @@
 
 #include <libxfce4ui/libxfce4ui.h>
 
-#include <gdk/gdkkeysyms.h>
 #if defined(GDK_WINDOWING_X11)
 #include <gdk/gdkx.h>
 #endif
@@ -290,7 +289,7 @@ terminal_window_init (TerminalWindow *window)
   GtkWidget      *vbox;
   gboolean        always_show_tabs;
   GdkScreen      *screen;
-  GdkVisual    *visual;
+  GdkVisual      *visual;
 
   window->preferences = terminal_preferences_get ();
 
@@ -321,7 +320,7 @@ terminal_window_init (TerminalWindow *window)
   g_signal_connect_after (G_OBJECT (accel_group), "accel-activate",
       G_CALLBACK (terminal_window_accel_activate), window);
 
-  window->vbox = vbox = gtk_vbox_new (FALSE, 0);
+  window->vbox = vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
   gtk_container_add (GTK_CONTAINER (window), vbox);
   gtk_widget_show (vbox);
 
@@ -497,11 +496,12 @@ terminal_window_confirm_close (TerminalWindow *window)
 
   dialog = gtk_dialog_new_with_buttons (_("Warning"), GTK_WINDOW (window),
                                         GTK_DIALOG_DESTROY_WITH_PARENT
-                                        | 0
                                         | GTK_DIALOG_MODAL,
+                                        GTK_STOCK_CANCEL,
+                                        GTK_RESPONSE_CANCEL,
                                         NULL);
 
-  gtk_dialog_add_button (GTK_DIALOG (dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
+  //gtk_dialog_add_button (GTK_DIALOG (dialog), GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL);
 
   button = xfce_gtk_button_new_mixed (GTK_STOCK_CLOSE, _("Close T_ab"));
   gtk_dialog_add_action_widget (GTK_DIALOG (dialog), button, GTK_RESPONSE_CLOSE);
@@ -512,8 +512,9 @@ terminal_window_confirm_close (TerminalWindow *window)
   gtk_widget_grab_focus (button);
   gtk_widget_show (button);
 
-  hbox = gtk_hbox_new (FALSE, 6);
+  hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 6);
   gtk_container_set_border_width (GTK_CONTAINER (hbox), 8);
+  gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), hbox, TRUE, TRUE, 0);
   gtk_widget_show (hbox);
 
   image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_WARNING, GTK_ICON_SIZE_DIALOG);
@@ -521,7 +522,7 @@ terminal_window_confirm_close (TerminalWindow *window)
   gtk_box_pack_start (GTK_BOX (hbox), image, FALSE, FALSE, 0);
   gtk_widget_show (image);
 
-  vbox = gtk_vbox_new (FALSE, 6);
+  vbox = gtk_box_new (GTK_ORIENTATION_VERTICAL, 6);
   gtk_box_pack_start (GTK_BOX (hbox), vbox, TRUE, TRUE, 0);
   gtk_widget_show (vbox);
 
@@ -934,27 +935,23 @@ terminal_window_notebook_page_removed (GtkNotebook    *notebook,
 
 static gboolean
 terminal_window_notebook_event_in_allocation (gint event_x,
-											  gint event_y,
-											  GtkWidget *widget)
+                                              gint event_y,
+                                              GtkWidget *widget)
 {
-	cairo_rectangle_int_t *allocation;
-	gtk_widget_get_allocation (widget, allocation);
-	
-	if(allocation == NULL)
-		return FALSE;
-	
-	
-	if (event_x >= allocation->x \
-		&& event_x <= allocation->x + allocation->width \
-		&& event_y >= allocation->y \
-		&& event_y <= allocation->y + allocation->height)
-		{
-			return TRUE;
-		}
-	else
-		return FALSE;
+  cairo_rectangle_int_t allocation;
+  gtk_widget_get_allocation (widget, &allocation);
 
+  if (event_x >= allocation.x \
+      && event_x <= allocation.x + allocation.width \
+      && event_y >= allocation.y \
+      && event_y <= allocation.y + allocation.height)
+    {
+      return TRUE;
+    }
+
+  return FALSE;
 }
+
 static gboolean
 terminal_window_notebook_button_press_event (GtkNotebook    *notebook,
                                              GdkEventButton *event,
@@ -1057,7 +1054,7 @@ terminal_window_notebook_drag_data_received (GtkWidget        *widget,
   GtkWidget  *child, *label;
   gint        i, n_pages;
   gboolean    succeed = FALSE;
-  cairo_rectangle_int_t *allocation;
+  cairo_rectangle_int_t allocation;
 
   terminal_return_if_fail (TERMINAL_IS_WINDOW (window));
   terminal_return_if_fail (TERMINAL_IS_SCREEN (widget));
@@ -1082,9 +1079,10 @@ terminal_window_notebook_drag_data_received (GtkWidget        *widget,
           /* get the child label */
           child = gtk_notebook_get_nth_page (GTK_NOTEBOOK (window->notebook), i);
           label = gtk_notebook_get_tab_label (GTK_NOTEBOOK (window->notebook), child);
-		  gtk_widget_get_allocation (label, allocation);
+          gtk_widget_get_allocation (label, &allocation);
+
           /* break if we have a matching drop position */
-          if (x < (allocation->x + allocation->width / 2))
+          if (x < (allocation.x + allocation.width / 2))
             break;
         }
 
@@ -1603,8 +1601,9 @@ terminal_window_action_set_title (GtkAction      *action,
                                             NULL);
       gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_CLOSE);
 
-      box = gtk_hbox_new (FALSE, 12);
+      box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 12);
       gtk_container_set_border_width (GTK_CONTAINER (box), 6);
+      gtk_box_pack_start (GTK_BOX (gtk_dialog_get_content_area (GTK_DIALOG (dialog))), box, TRUE, TRUE, 0);
       gtk_widget_show (box);
 
       label = gtk_label_new_with_mnemonic (_("_Title:"));


### PR DESCRIPTION
As requested by https://github.com/f2404/xfce4-terminal3/issues/6

The changes are mostly migrating from deprecated `GdkColor` to `GdkRGBA`, and replacing some deprecated methods.